### PR TITLE
Adds initial math support

### DIFF
--- a/src/AstEditor.tsx
+++ b/src/AstEditor.tsx
@@ -1144,6 +1144,14 @@ function MathEditor(props: NodeEditorProps<BinaryNode>): JSX.Element {
 }
 
 function flattenMathParts(ast: AST, onChange: OnChange, collectedParts: MathPart[] = []): MathPart[] {
+  function onChangeOperator(newOperator: string) {
+    if (Object.keys(Consts.mathOperators).includes(newOperator)) {
+      onChange({ ...ast, value: newOperator } as BinaryNode);
+    } else {
+      throw new Error("Not a valid math operator");
+    }
+  }
+
   if (ast.type == "binary") {
     flattenMathParts(
       ast.lhs, 
@@ -1153,7 +1161,7 @@ function flattenMathParts(ast: AST, onChange: OnChange, collectedParts: MathPart
     collectedParts.push({
      type: "operator",
      operator: ast.value,
-     onChangeOperator: () => { /* TODO */ }
+     onChangeOperator
     });
     flattenMathParts(
       ast.rhs, 

--- a/src/AstEditor.tsx
+++ b/src/AstEditor.tsx
@@ -32,6 +32,7 @@ import * as _consts from "./Consts";
 import { StandardDefaultProvider } from "./util/DefaultProvider";
 
 import * as Types from "./Types";
+import { Theme } from "./Theme";
 import _paths from "./schema/PathSuggester";
 import * as SchemaProvider from "./schema/SchemaProvider";
 // re-export types for theming purposes
@@ -1104,7 +1105,7 @@ function MathContainerEditor(props: NodeEditorProps<BinaryNode>): JSX.Element {
   const [parsing, setParsing] = useState<ParsingState>({
     inProgress: false,
   });
-  const nodes = flattenMathNodes(props);
+  const nodes = flattenMathNodes(props, theme);
   const changeType = () => { props.onChange(nextAst(props.ast, defaultProvider)) };
 
   function onChangeText(newText: string) {
@@ -1143,13 +1144,11 @@ function MathContainerEditor(props: NodeEditorProps<BinaryNode>): JSX.Element {
   );
 }
 
-function flattenMathNodes({ ast, ...rest }: NodeEditorProps<AST>, collectedNodes: JSX.Element[] = []): JSX.Element[] {
-  const { theme } = Context.useContainer();
-
+function flattenMathNodes({ ast, ...rest }: NodeEditorProps<AST>, theme: Theme, collectedNodes: JSX.Element[] = []): JSX.Element[] {
   if (ast.type == "binary") {
-    flattenMathNodes({ ast: ast.lhs, ...rest }, collectedNodes);
+    flattenMathNodes({ ast: ast.lhs, ...rest }, theme, collectedNodes);
     collectedNodes.push(<theme.MathBinaryOperatorEditor ast={ast} {...rest}/>);
-    flattenMathNodes({ ast: ast.rhs, ...rest }, collectedNodes);
+    flattenMathNodes({ ast: ast.rhs, ...rest }, theme, collectedNodes);
   } else if (ast.type === "path") {
     collectedNodes.push(<theme.MathPathEditor ast={ast} serializedPath={serializer(ast)} {...rest} />);
   } else if (
@@ -1161,7 +1160,7 @@ function flattenMathNodes({ ast, ...rest }: NodeEditorProps<AST>, collectedNodes
   } else if (ast.type === "block") {
     const groupedNodes = []
     for (let expression of ast.expressions) {
-      flattenMathNodes({ ast: expression, ...rest}, groupedNodes);
+      flattenMathNodes({ ast: expression, ...rest}, theme, groupedNodes);
     }
     collectedNodes.push(
       <theme.MathBlockEditor ast={ast} {...rest}>

--- a/src/AstEditor.tsx
+++ b/src/AstEditor.tsx
@@ -1147,23 +1147,23 @@ function MathContainerEditor(props: NodeEditorProps<BinaryNode>): JSX.Element {
 function flattenMathNodes({ ast, ...rest }: NodeEditorProps<AST>, theme: Theme, collectedNodes: JSX.Element[] = []): JSX.Element[] {
   if (ast.type == "binary") {
     flattenMathNodes({ ast: ast.lhs, ...rest }, theme, collectedNodes);
-    collectedNodes.push(<theme.MathBinaryOperatorEditor ast={ast} {...rest}/>);
+    collectedNodes.push(<theme.MathBinaryOperatorEditor key={collectedNodes.length} ast={ast} {...rest}/>);
     flattenMathNodes({ ast: ast.rhs, ...rest }, theme, collectedNodes);
   } else if (ast.type === "path") {
-    collectedNodes.push(<theme.MathPathEditor ast={ast} serializedPath={serializer(ast)} {...rest} />);
+    collectedNodes.push(<theme.MathPathEditor key={collectedNodes.length} ast={ast} serializedPath={serializer(ast)} {...rest} />);
   } else if (
     ast.type === "number" ||
     ast.type === "value" ||
     ast.type === "string"
   ) {
-    collectedNodes.push(<theme.MathLiteralEditor ast={ast} {...rest}/>);
+    collectedNodes.push(<theme.MathLiteralEditor key={collectedNodes.length} ast={ast} {...rest}/>);
   } else if (ast.type === "block") {
     const groupedNodes = []
     for (let expression of ast.expressions) {
       flattenMathNodes({ ast: expression, ...rest}, theme, groupedNodes);
     }
     collectedNodes.push(
-      <theme.MathBlockEditor ast={ast} {...rest}>
+      <theme.MathBlockEditor key={collectedNodes.length} ast={ast} {...rest}>
         {groupedNodes}
       </theme.MathBlockEditor>
     );

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -51,6 +51,15 @@ export type Theme = {
   VariableEditor: Comp<VariableEditorProps>;
   LeafValueEditor: Comp<LeafValueEditorProps>;
   PathEditor: Comp<PathEditorProps>;
+
+  /*
+      Math editors
+    */
+  MathContainerEditor: Comp<MathContainerEditorProps>;
+  MathBinaryOperatorEditor: Comp<MathBinaryOperatorEditorProps>;
+  MathPathEditor: Comp<MathPathEditorProps>;
+  MathLiteralEditor: Comp<MathLiteralEditorProps>;
+  MathBlockEditor: Comp<MathBlockEditorProps>;
 };
 
 export interface IDETextareaProps {
@@ -177,4 +186,24 @@ export type BindEditorProps = NodeEditorProps<BindNode> & {
   rhs: JSX.Element;
   lhsProps: NodeEditorProps<AST>;
   rhsProps: NodeEditorProps<AST>;
+};
+
+export type MathContainerEditorProps = NodeEditorProps<BinaryNode> & {
+  children: Children;
+  text: string;
+  onChangeText: OnChange<string>;
+  parsing: ParsingState;
+  changeType: Callback;
+};
+
+export type MathBinaryOperatorEditorProps = NodeEditorProps<BinaryNode> & {};
+
+export type MathPathEditorProps = NodeEditorProps<PathNode> & {
+  serializedPath: string;
+};
+
+export type MathLiteralEditorProps = NodeEditorProps<LiteralNode> & {};
+
+export type MathBlockEditorProps = NodeEditorProps<BlockNode> & {
+  children: Children;
 };

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -55,11 +55,7 @@ export type Theme = {
   /*
       Math editors
     */
-  MathContainerEditor: Comp<MathContainerEditorProps>;
-  MathBinaryOperatorEditor: Comp<MathBinaryOperatorEditorProps>;
-  MathPathEditor: Comp<MathPathEditorProps>;
-  MathLiteralEditor: Comp<MathLiteralEditorProps>;
-  MathBlockEditor: Comp<MathBlockEditorProps>;
+  MathEditor: Comp<MathEditorProps>;
 };
 
 export interface IDETextareaProps {
@@ -68,26 +64,24 @@ export interface IDETextareaProps {
   parsing: ParsingState;
 }
 
+export type ChildNodeProps = {
+  editor: JSX.Element;
+  ast: NodeEditorProps<AST>["ast"];
+  onChange: NodeEditorProps<AST>["onChange"];
+};
+
 export type CombinerEditorProps = NodeEditorProps<BinaryNode> & {
   addNew: Callback;
   removeLast: Callback;
   combinerOperators: { [key: string]: string };
   // @deprecated. use ChildNodes
   children: JSX.Element[];
-  childNodes: {
-    editor: JSX.Element;
-    ast: NodeEditorProps<AST>["ast"];
-    onChange: NodeEditorProps<AST>["onChange"];
-  }[];
+  childNodes: ChildNodeProps[];
 };
 
 export type BlockEditorProps = NodeEditorProps<BlockNode> & {
   children: Children;
-  childNodes: {
-    editor: JSX.Element;
-    ast: NodeEditorProps<AST>["ast"];
-    onChange: NodeEditorProps<AST>["onChange"];
-  }[];
+  childNodes: ChildNodeProps[];
 };
 
 export type ObjectUnaryEditorProps = NodeEditorProps<ObjectUnaryNode> & {
@@ -107,12 +101,7 @@ export type VariableEditorProps = NodeEditorProps<VariableNode> & {
 };
 
 export type ArrayUnaryEditorProps = NodeEditorProps<ArrayUnaryNode> & {
-  children: {
-    editor: JSX.Element;
-    remove: Callback;
-    ast: NodeEditorProps<AST>["ast"];
-    onChange: NodeEditorProps<AST>["onChange"];
-  }[];
+  children: (ChildNodeProps & { remove: Callback })[];
   addNew: Callback;
   removeLast: Callback;
 };
@@ -164,20 +153,12 @@ export type ApplyEditorProps = NodeEditorProps<ApplyNode> & {
   lhs: JSX.Element;
   children: Children;
   lhsProps: NodeEditorProps<AST>;
-  childNodes: {
-    editor: JSX.Element;
-    ast: NodeEditorProps<AST>["ast"];
-    onChange: NodeEditorProps<AST>["onChange"];
-  }[];
+  childNodes: ChildNodeProps[];
 };
 
 export type FunctionEditorProps = NodeEditorProps<FunctionNode> & {
   args: Children;
-  argumentNodes: {
-    editor: JSX.Element;
-    ast: NodeEditorProps<AST>["ast"];
-    onChange: NodeEditorProps<AST>["onChange"];
-  }[];
+  argumentNodes: ChildNodeProps[];
   changeProcedure: OnChange<String>;
 };
 
@@ -188,22 +169,16 @@ export type BindEditorProps = NodeEditorProps<BindNode> & {
   rhsProps: NodeEditorProps<AST>;
 };
 
-export type MathContainerEditorProps = NodeEditorProps<BinaryNode> & {
-  children: Children;
+export type MathEditorProps = NodeEditorProps<BinaryNode> & {
   text: string;
-  onChangeText: OnChange<string>;
-  parsing: ParsingState;
+  children: MathPart[];
   changeType: Callback;
-};
+} & IDETextareaProps;
 
-export type MathBinaryOperatorEditorProps = NodeEditorProps<BinaryNode> & {};
-
-export type MathPathEditorProps = NodeEditorProps<PathNode> & {
-  serializedPath: string;
-};
-
-export type MathLiteralEditorProps = NodeEditorProps<LiteralNode> & {};
-
-export type MathBlockEditorProps = NodeEditorProps<BlockNode> & {
-  children: Children;
-};
+export type MathPart =
+  | ({ type: "ast", children?: MathPart[] } & ChildNodeProps)
+  | {
+      type: "operator";
+      operator: string;
+      onChangeOperator: OnChange<string>;
+    };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,11 +22,13 @@ const set = `[Q = 0, Q = 1, Q = 3]`;
 const obj = `{"one":Q = 0, "two": Q = 1,  "three": Q = 3}`;
 const cond = `Q = 0 ? "Tier 1" : Q =1 ? "Tier 2" : "Tier 3"`;
 const singleCond = `($Q := products[product_id="seat"].quantity; $Q = 0 ? $tier1 : $Q = 1 ? $tier2 : $defaultTier)`;
+const fizzbuzz = `Q % 3 = 0 ? "Fizz" : Q % 5 = 0 ? "Buzz" : Q`;
+const math = `Q + 3 * 2 / (16 - 4)`;
 
 const defaultText: string = apply;
 const introspection = jsonata(`**[type="name"].value`);
 
-const options = [apply, set, obj, cond, singleCond];
+const options = [apply, set, obj, cond, singleCond, fizzbuzz, math];
 
 // TODO : Make this recursive, smarter
 const NodeWhitelist = jsonata(`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ const obj = `{"one":Q = 0, "two": Q = 1,  "three": Q = 3}`;
 const cond = `Q = 0 ? "Tier 1" : Q =1 ? "Tier 2" : "Tier 3"`;
 const singleCond = `($Q := products[product_id="seat"].quantity; $Q = 0 ? $tier1 : $Q = 1 ? $tier2 : $defaultTier)`;
 const fizzbuzz = `Q % 3 = 0 ? "Fizz" : Q % 5 = 0 ? "Buzz" : Q`;
-const math = `Q + 3 * 2 / (16 - 4)`;
+const math = `Q + 3 * 2 / (16 - 4 - Q) + $min(Q + 1)`;
 
 const defaultText: string = apply;
 const introspection = jsonata(`**[type="name"].value`);

--- a/src/theme/MathTheme.tsx
+++ b/src/theme/MathTheme.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import styled from "styled-components";
+import { Badge } from "react-bootstrap";
+
+import { serializer } from "jsonata-ui-core";
+import { AST, NodeEditorProps } from "../Types";
+import {
+  Theme,
+  VariableEditorProps,
+  PathEditorProps,
+  BlockEditorProps,
+  FunctionEditorProps,
+  MathEditorProps
+} from "../Theme";
+
+const MathBadge = styled(Badge)`
+  font-size: 100%;
+`;
+
+const MathGroup = styled.span`
+  margin-left: 0;
+  margin-right: 0;
+
+  *:first-child {
+    margin-left: 0;
+  }
+  *:last-child {
+    margin-right: 0;
+  }
+`;
+
+function DefaultEditor(props: NodeEditorProps<AST>) {
+  const serialized = serializer(props.ast);
+  return <span>{serialized}</span>;
+}
+
+function VariableEditor(props: VariableEditorProps) {
+  const serialized = serializer(props.ast);
+  return <MathBadge variant="primary">{serialized}</MathBadge>;
+}
+
+function PathEditor(props: PathEditorProps) {
+  const serialized = serializer(props.ast);
+  return <MathBadge variant="primary">{serialized}</MathBadge>;
+}
+
+function BlockEditor(props: BlockEditorProps) {
+  return (
+    <>
+      <span style={{ marginRight: 0 }}>(</span>
+      {props.children}
+      <span style={{ marginLeft: 0 }}>)</span>
+    </>
+  );
+}
+
+function FunctionEditor(props: FunctionEditorProps) {
+  return (
+    <>
+      <span style={{fontFamily: "monospace"}}>
+        ${props.ast.procedure.value}
+      </span>
+      (<span>{props.args}</span>)
+    </>
+  );
+}
+
+function MathEditor(props: MathEditorProps) {
+  return (
+    <>
+      {props.children.map(part => {
+        if (part.type === "ast") {
+          return part.editor;
+        } else if (part.type === "operator") {
+          return (
+            <span>
+              <b>{part.operator === "*" ? "x" : part.operator}</b>
+            </span>
+          );
+        }
+      })}
+    </>
+  );
+}
+
+export const MathTheme = {
+  /*
+    Base editors
+  */
+  Base: props => props.editor,
+  RootNodeEditor: props => props.editor,
+  IDETextarea: props => <div />,
+
+  /*
+    Compound editors
+  */
+  ComparisonEditor: DefaultEditor,
+  CombinerEditor: DefaultEditor,
+  BlockEditor,
+  ConditionEditor: DefaultEditor,
+  ObjectUnaryEditor: DefaultEditor,
+  ArrayUnaryEditor: DefaultEditor,
+  ApplyEditor: DefaultEditor,
+  FunctionEditor,
+
+  /*
+    Leaf editors
+   */
+  BindEditor: DefaultEditor,
+  VariableEditor,
+  LeafValueEditor: DefaultEditor,
+  PathEditor,
+
+  /*
+    Math editors
+  */
+  MathEditor
+} as Theme;


### PR DESCRIPTION
This adds initial math support to jsonata-visual-editor.

- Math binary operators are flattened into an array of theme-provided components
- The array is used as children for a math container theme-provided component
- Currently the editing ability is through the math container component in the theme, when clicked the rendered AST will become an input which can be edited, and won't allow anything other than a valid math expression to validate (esc or enter will dismiss)
- The type changer is supported, but only from string -> math expression - i.e. switch the type to string, type a valid math expression like "Q + 1" and then hit the type changer, it will be upgraded to math

Lots of things to still work out, like:
- Better editing experience
- Identifier validation
- Better rendering of the expression in the theme

But this goes a long way to allowing editable math expressions and typing them in advanced mode will no longer result in uncaught thrown exceptions.

Given that each part of the expression is rendered by a different theme-provided component much fancier stuff can be done in future (like a popover of available identifier when an identifier is clicked etc.)