### PR TITLE
Add a more sophisticated default basic expression checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonata-visual-editor",
-  "version": "0.3.9",
+  "version": "0.3.10-0",
   "description": "Visual editor for JSONata expressions. Themeable to your needs, default theme is Boostrap 4",
   "keywords": [
     "jsonata"

--- a/src/AstEditor.tsx
+++ b/src/AstEditor.tsx
@@ -79,7 +79,7 @@ type State =
     };
 
 export function Editor(props: Types.EditorProps) {
-  const { isValidBasicExpression = DefaultValidBasicExpression, text } = props;
+  const { isValidBasicExpression = defaultIsValidBasicExpression, text } = props;
   const initialState = (): State => {
     try {
       let newAst = jsonata(props.text).ast() as AST;
@@ -169,8 +169,16 @@ export function Editor(props: Types.EditorProps) {
   );
 }
 
-function DefaultValidBasicExpression(ast: AST): null {
-  return null;
+export function defaultIsValidBasicExpression(ast: AST): string | null {
+  const advancedOnly = jsonata(`**[type = "block" or type = "lambda" or type = "transform" or (type = "binary" and value = "&")]`);
+  try {
+    if(advancedOnly.evaluate(ast)) {
+      return "Can't use basic editor for advanced expressions. Try a simpler expression.";
+    } 
+  } catch (e) {
+    return "Failed to evaluate expression";
+  }
+  return null;;
 }
 
 function NodeEditor(props: NodeEditorProps<AST>): JSX.Element {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { Col, Badge, Button } from "react-bootstrap";
 import jsonata from "jsonata";
 import { serializer, ConditionNode } from "jsonata-ui-core";
 
-import { Editor } from "./AstEditor";
+import { Editor, defaultIsValidBasicExpression } from "./AstEditor";
 import { DefaultTheme } from "./theme/DefaultTheme";
 import { AST } from "./Types";
 import { makeSchemaProvider } from "./schema/SchemaProvider";
@@ -38,12 +38,18 @@ const NodeWhitelist = jsonata(`
 `);
 
 function isValidBasicExpression(newValue: AST): string | null {
-  try {
-    if (NodeWhitelist.evaluate(newValue)) {
-      return null;
+  // Check the default basic expression first if you just want to add to it
+  const defaultResult = defaultIsValidBasicExpression(newValue);
+
+  if (defaultResult === null) {
+    try {
+      if (NodeWhitelist.evaluate(newValue)) {
+        return null;
+      }
+    } catch (e) {}
+    return "Can't use basic editor for advanced expressions. Try a simpler expression.";
     }
-  } catch (e) {}
-  return "Can't use basic editor for advanced expressions. Try a simpler expression.";
+  return defaultResult;
 }
 
 type VariableEditor = typeof DefaultTheme.VariableEditor;


### PR DESCRIPTION
Previously the default was not to classify anything as an advanced-only expression, however that means out of the box the editor will explode on things that it doesn't support after entering an advanced expression and switching back to basic mode.

By providing a sane default, there's less of a chance of that, but it still gives the user the option to completely override it if they build additional support in their theme for something the default theme doesn't support, or to provide additional restrictions on top of the new default check.

Note, I'm sure there are other things that don't work in UI mode in the default theme, this checks for the obvious ones and can be improved/changed over time.